### PR TITLE
# Added new UserInputManager to re-apply previously input data 

### DIFF
--- a/HBERT Revit Installer/HBERT Installer.vdproj
+++ b/HBERT Revit Installer/HBERT Installer.vdproj
@@ -142,25 +142,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_DCC6A81982994D59B58895127C0E030A"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_8CFFAAB2421840619E03995C0D297141"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_C140C06B18B54EDA83E80A525BFA82D5"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_88943848056C4FCB824BB4B2D99215F1"
+        "OwnerKey" = "8:_25310D74FA76E8FE2C76876862F7C77C"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -172,7 +154,25 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_25310D74FA76E8FE2C76876862F7C77C"
+        "OwnerKey" = "8:_88943848056C4FCB824BB4B2D99215F1"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_C140C06B18B54EDA83E80A525BFA82D5"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_8CFFAAB2421840619E03995C0D297141"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_DCC6A81982994D59B58895127C0E030A"
         "MsmSig" = "8:_UNDEFINED"
         }
     }
@@ -297,11 +297,6 @@
             "AssemblyAsmDisplayName" = "8:Xceed.Wpf.Toolkit, Version=3.7.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
-                    "_25310D74FA76E8FE2C76876862F7C77C"
-                    {
-                    "Name" = "8:Xceed.Wpf.Toolkit.DLL"
-                    "Attributes" = "3:512"
-                    }
                 }
             "SourcePath" = "8:Xceed.Wpf.Toolkit.DLL"
             "TargetName" = "8:"
@@ -365,7 +360,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CarbonEmissionTool, Version=1.1.2.0, Culture=neutral, processorArchitecture=AMD64"
+            "AssemblyAsmDisplayName" = "8:CarbonEmissionTool, Version=2.1.0.0, Culture=neutral, processorArchitecture=AMD64"
                 "ScatterAssemblies"
                 {
                     "_6250165CFCB8427AACC7D1CDD3D5E00C"
@@ -479,11 +474,6 @@
             "AssemblyAsmDisplayName" = "8:Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
-                    "_88049715FBB4F0CBB4152F3F7490339D"
-                    {
-                    "Name" = "8:Newtonsoft.Json.DLL"
-                    "Attributes" = "3:512"
-                    }
                 }
             "SourcePath" = "8:Newtonsoft.Json.DLL"
             "TargetName" = "8:"
@@ -880,15 +870,15 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:HBERT Revit AddIn"
-        "ProductCode" = "8:{B486E3D9-57B2-4473-BBA1-1FDEDA582977}"
-        "PackageCode" = "8:{5E9C31AA-A0E7-4455-ACD1-DB1D1332404B}"
+        "ProductCode" = "8:{1E0051AC-69B8-49BB-94C4-0684642AF55C}"
+        "PackageCode" = "8:{F1CE8870-50C9-4AD1-80BE-E98E67967822}"
         "UpgradeCode" = "8:{4B479C43-03F5-4C54-82CC-D6354DFB3425}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
         "InstallAllUsers" = "11:FALSE"
-        "ProductVersion" = "8:2.0.1"
+        "ProductVersion" = "8:2.1.0"
         "Manufacturer" = "8:Hawkins Brown Architects"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:"

--- a/HBERT_Carbon_Emission_Tool/CarbonEmissionTool.csproj
+++ b/HBERT_Carbon_Emission_Tool/CarbonEmissionTool.csproj
@@ -125,6 +125,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Models\DataCapturing\InputCapture.cs" />
     <Compile Include="Models\Dialogs\HelpDialog.cs" />
     <Compile Include="Models\ElementFilters\TextNoteTypeFilter.cs" />
     <Compile Include="Models\Headings\HeadingGenerator.cs" />
@@ -196,6 +197,7 @@
     <Compile Include="Models\Main\CarbonEmissionToolMain.cs" />
     <Compile Include="Models\Utilities\ViewportUtils.cs" />
     <Compile Include="Services\ApplicationServices.cs" />
+    <Compile Include="Services\UserInputMonitor.cs" />
     <Compile Include="Settings\ApplicationSettings.cs" />
     <Compile Include="Services\Caches\CarbonDataCache.cs" />
     <Compile Include="Services\Caches\ChartColorCache.cs" />
@@ -205,6 +207,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ViewModels\Commands\ProjectTypeSelectionCommand.cs" />
     <Compile Include="ViewModels\Commands\RunHbertCommand.cs" />
+    <Compile Include="ViewModels\Converters\ProjectTypeToBoolConverter.cs" />
     <Compile Include="ViewModels\HbertMainViewModel.cs" />
     <Compile Include="ViewModels\PublishPageViewModel.cs" />
     <Compile Include="Models\Validation\ComboBoxSelectedItemValidation.cs" />

--- a/HBERT_Carbon_Emission_Tool/Models/DataCapturing/InputCapture.cs
+++ b/HBERT_Carbon_Emission_Tool/Models/DataCapturing/InputCapture.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Autodesk.Revit.DB;
+
+namespace CarbonEmissionTool.Models
+{
+    /// <summary>
+    /// Stores data input by the user for a given document, enabling the HBERT form to be
+    /// re-populated with the same data the next time it is opened.
+    /// </summary>
+    class InputCapture
+    {
+        /// <summary>
+        /// The address of the project input by the user.
+        /// </summary>
+        public string Address { get; }
+
+        /// <summary>
+        /// The name of the project input by the user.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The revision of the project input by the user.
+        /// </summary>
+        public string Revision { get; }
+
+        /// <summary>
+        /// The RIBA workstage input by the user.
+        /// </summary>
+        public RibaWorkstage RibaWorkstage { get; }
+
+        /// <summary>
+        /// The project type input by the user.
+        /// </summary>
+        public ProjectType ProjectType { get; }
+
+        /// <summary>
+        /// The floor area input by the user.
+        /// </summary>
+        public double FloorArea { get; }
+
+        /// <summary>
+        /// The building elements selected by the user.
+        /// </summary>
+        public CheckBoxItemCollection BuildElements { get; }
+
+        /// <summary>
+        /// The sectors selected by the user.
+        /// </summary>
+        public CheckBoxItemCollection Sectors { get; }
+
+        /// <summary>
+        /// The document hashcode which the session inputs belong to.
+        /// </summary>
+        public int DocumentHash { get; }
+
+        /// <summary>
+        /// Constructs a new <see cref="InputCapture"/> from the provided <paramref name="projectDetails"/>.
+        /// </summary>
+        public InputCapture(Document document, IProjectDetails projectDetails)
+        {
+            this.DocumentHash = document.GetHashCode();
+
+            this.Name = projectDetails.Name;
+            this.Address = projectDetails.Address;
+            this.Revision = projectDetails.Revision;
+            this.ProjectType = projectDetails.ProjectType;
+            this.RibaWorkstage = projectDetails.RibaWorkstage;
+            this.BuildElements = projectDetails.BuildElements;
+            this.Sectors = projectDetails.Sectors;
+            this.FloorArea = projectDetails.FloorArea;
+        }
+    }
+}

--- a/HBERT_Carbon_Emission_Tool/Models/Interfaces/IProjectDetails.cs
+++ b/HBERT_Carbon_Emission_Tool/Models/Interfaces/IProjectDetails.cs
@@ -47,10 +47,5 @@ namespace CarbonEmissionTool.Models
         /// The building sectors displayed as check boxes on the UI window.
         /// </summary>
         CheckBoxItemCollection Sectors { get; }
-
-        /// <summary>
-        /// The <see cref="IDataCapture"/> object.
-        /// </summary>
-        IDataCapture DataCapture { get; }
     }
 }

--- a/HBERT_Carbon_Emission_Tool/Models/Main/CarbonEmissionToolMain.cs
+++ b/HBERT_Carbon_Emission_Tool/Models/Main/CarbonEmissionToolMain.cs
@@ -33,7 +33,9 @@ namespace CarbonEmissionTool.Models
 
                     HeadingGenerator.Create(projectDetails, treeChart, stackedBarChart, newSheet);
 
-                    projectDetails.DataCapture.Upload(projectDetails, carbonDataCache);
+                    ApplicationServices.DataCapture.Upload(projectDetails, carbonDataCache);
+
+                    UserInputMonitor.RegisterUserInputs(projectDetails);
                 }
 
                 transaction.Commit();

--- a/HBERT_Carbon_Emission_Tool/Models/Utilities/NameUtils.cs
+++ b/HBERT_Carbon_Emission_Tool/Models/Utilities/NameUtils.cs
@@ -27,7 +27,7 @@ namespace CarbonEmissionTool.Models
         /// <summary>
         /// Validates file names by removing any illegal characters.
         /// </summary>
-        internal static string ValidateFileName(string projectName) 
+        public static string ValidateFileName(string projectName) 
         {
             Regex cleanExpression = new Regex(@"[][\:{}|;<>?`~]");
 

--- a/HBERT_Carbon_Emission_Tool/Properties/AssemblyInfo.cs
+++ b/HBERT_Carbon_Emission_Tool/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.2.0")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/HBERT_Carbon_Emission_Tool/Services/ApplicationServices.cs
+++ b/HBERT_Carbon_Emission_Tool/Services/ApplicationServices.cs
@@ -54,10 +54,12 @@ namespace CarbonEmissionTool.Services
         /// </summary>
         public static Regex CleanExpression = new Regex($"[{ApplicationServices.InvalidCharacters}]");
 
+        public static IDataCapture DataCapture { get; private set; }
+
         /// <summary>
         /// Processes which are required for the warning tool on startup.
         /// </summary>
-        public static void OnStartup(Document document)
+        public static void OnStartup(Document document, IDataCapture dataCapture)
         {
             Document = document;
 
@@ -76,6 +78,8 @@ namespace CarbonEmissionTool.Services
             CarbonDataCache = new CarbonDataCache();
             
             SolidFillPatternId = new ElementId(3);
+
+            DataCapture = dataCapture;
         }
 
         /// <summary>

--- a/HBERT_Carbon_Emission_Tool/Services/UserInputMonitor.cs
+++ b/HBERT_Carbon_Emission_Tool/Services/UserInputMonitor.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using CarbonEmissionTool.Models;
+
+namespace CarbonEmissionTool.Services
+{
+    /// <summary>
+    /// Class which stores user input data and re-applies the data if they open the app multiple times in the
+    /// same Revit session.
+    /// </summary>
+    static class UserInputMonitor
+    {
+        /// <summary>
+        /// A list of all the <see cref="InputCapture"/> generated in the current Revit session.
+        /// </summary>
+        public static List<InputCapture> InputCaptures { get; }
+
+        /// <summary>
+        /// Constructs a new <see cref="UserInputMonitor"/>.
+        /// </summary>
+        static UserInputMonitor()
+        {
+            InputCaptures = new List<InputCapture>();
+        }
+
+        /// <summary>
+        /// Adds a <see cref="InputCapture"/> to the monitor.
+        /// </summary>
+        public static void RegisterUserInputs(IProjectDetails projectDetails)
+        {
+            var document = ApplicationServices.Document;
+            var documentHash = document.GetHashCode();
+
+            var inputCapture = new InputCapture(ApplicationServices.Document, projectDetails);
+
+            var existingInputCapture = UserInputMonitor.GetCapture(document);
+
+            // If the active document hash is found in the InputCaptures, remove it and replace it 
+            // with the new one to ensure only the most recent data inputs are reapplied.
+            if (existingInputCapture != null)
+            {
+                InputCaptures.Remove(existingInputCapture);
+            }
+
+            InputCaptures.Add(inputCapture);
+        }
+
+        /// <summary>
+        /// Returns true if the provided document hash matches with an <see cref="InputCapture"/> stored in this
+        /// monitor.
+        /// </summary>
+        public static bool HasInputCapture(Document document)
+        {
+            return InputCaptures.Any(capture => capture.DocumentHash == document.GetHashCode());
+        }
+
+        /// <summary>
+        /// Returns an <see cref="InputCapture"/> which matches with the provided documents hashcode.
+        /// </summary>
+        public static InputCapture GetCapture(Document document)
+        {
+            var documentHashcode = document.GetHashCode();
+
+            return InputCaptures.Find(capture => capture.DocumentHash == documentHashcode);
+        }
+    }
+}

--- a/HBERT_Carbon_Emission_Tool/ViewModels/CarbonEmissionToolViewModel.cs
+++ b/HBERT_Carbon_Emission_Tool/ViewModels/CarbonEmissionToolViewModel.cs
@@ -17,6 +17,7 @@ namespace CarbonEmissionTool.ViewModels
         private string _revision;
         private double _floorArea = 1.0;
         private RibaWorkstage _ribaWorkstage = RibaWorkstage.One;
+        private ProjectType _projectType;
 
         #region IProjectDetails implementation
         /// <summary>
@@ -79,7 +80,16 @@ namespace CarbonEmissionTool.ViewModels
             }
         }
 
-        public ProjectType ProjectType { get; set; }
+        public ProjectType ProjectType 
+        { 
+            get => _projectType;
+            set
+            {
+                _projectType = value;
+
+                OnPropertyChanged(nameof(ProjectType));
+            }
+        }
 
         public double FloorArea
         {
@@ -127,30 +137,48 @@ namespace CarbonEmissionTool.ViewModels
         public ICommand UpdateProjectType { get; }
 
         /// <summary>
-        /// The <see cref="IDataCapture"/> object.
-        /// </summary>
-        public IDataCapture DataCapture { get; }
-
-        /// <summary>
         /// Constructs a new <see cref="CarbonEmissionToolViewModel"/>.
         /// </summary>
         public CarbonEmissionToolViewModel()
         {
-            var projectInfo = ApplicationServices.Document.ProjectInformation;
+            var document = ApplicationServices.Document;
 
-            this.Name = projectInfo.Name;
+            if (UserInputMonitor.HasInputCapture(document))
+            {
+                var inputCapture = UserInputMonitor.GetCapture(document);
 
-            this.Address = projectInfo.Address.Replace(Environment.NewLine, " ");
+                this.Name = inputCapture.Name;
 
-            this.BuildElements = new CheckBoxItemCollection(ApplicationSettings.BuildingElementNames);
+                this.Revision = inputCapture.Revision;
 
-            this.Sectors = new CheckBoxItemCollection(ApplicationSettings.SectorNames);
-            
+                this.Address = inputCapture.Address;
+
+                this.FloorArea = (int)inputCapture.FloorArea;
+
+                this.BuildElements = inputCapture.BuildElements;
+
+                this.Sectors = inputCapture.Sectors;
+
+                this.RibaWorkstage = inputCapture.RibaWorkstage;
+
+                this.ProjectType = inputCapture.ProjectType;
+            }
+            else
+            {
+                var projectInfo = document.ProjectInformation;
+
+                this.Name = projectInfo.Name;
+
+                this.Address = projectInfo.Address.Replace(Environment.NewLine, " ");
+
+                this.BuildElements = new CheckBoxItemCollection(ApplicationSettings.BuildingElementNames);
+
+                this.Sectors = new CheckBoxItemCollection(ApplicationSettings.SectorNames);
+            }
+
             this.RibaWorkstages = Enum.GetValues(typeof(RibaWorkstage)).OfType<RibaWorkstage>().ToList();
 
             this.UpdateProjectType = new ProjectTypeSelectionCommand(this);
-
-            this.DataCapture = new DataCapture();
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/HBERT_Carbon_Emission_Tool/ViewModels/Commands/ProjectTypeSelectionCommand.cs
+++ b/HBERT_Carbon_Emission_Tool/ViewModels/Commands/ProjectTypeSelectionCommand.cs
@@ -4,6 +4,9 @@ using CarbonEmissionTool.Models;
 
 namespace CarbonEmissionTool.ViewModels
 {
+    /// <summary>
+    /// Currently not used.
+    /// </summary>
     public class ProjectTypeSelectionCommand : ICommand
     {
         private IProjectDetails _projectDetails;

--- a/HBERT_Carbon_Emission_Tool/ViewModels/Converters/ProjectTypeToBoolConverter.cs
+++ b/HBERT_Carbon_Emission_Tool/ViewModels/Converters/ProjectTypeToBoolConverter.cs
@@ -1,0 +1,32 @@
+﻿using CarbonEmissionTool.Models;
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CarbonEmissionTool.ViewModels
+{
+    class ProjectTypeToBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var projectType = (ProjectType)value;
+
+            var projectTypeSender = Enum.Parse(typeof(ProjectType), parameter.ToString());
+
+            return (ProjectType)projectTypeSender == projectType;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var projectTypeSender = (ProjectType)Enum.Parse(typeof(ProjectType), parameter.ToString());
+
+            var isChecked = value != null && (bool) value;
+
+            var inverseProjectType = projectTypeSender == ProjectType.NewBuild
+                ? ProjectType.Refurbishment
+                : ProjectType.NewBuild;
+
+            return isChecked ? projectTypeSender : inverseProjectType;
+        }
+    }
+}

--- a/HBERT_Carbon_Emission_Tool/Views/Pages/CarbonEmissionToolPage.xaml
+++ b/HBERT_Carbon_Emission_Tool/Views/Pages/CarbonEmissionToolPage.xaml
@@ -24,6 +24,9 @@
 
             <!-- View model instance -->
             <viewModels:CarbonEmissionToolViewModel x:Key="CarbonEmissionToolViewModel"/>
+
+            <!-- Value converters -->
+            <viewModels:ProjectTypeToBoolConverter x:Key="ProjectTypeToBoolConverter"/>
         </ResourceDictionary>
     </Page.Resources>
 
@@ -193,21 +196,21 @@
 
             <WrapPanel Orientation="Horizontal">
 
-                <!-- NEW BUILD RADIO BUTTON -->
+                <!-- NEW BUILD RADIO BUTTONCommand="{Binding UpdateProjectType}"
+                              CommandParameter="NewBuild" -->
                 <ToggleButton x:Name="NewBuildButton"
                               Content="New Build" 
                               Style="{StaticResource BuildingTypeButtonStyle}" 
                               Checked="NewBuildButton_Checked"
-                              Command="{Binding UpdateProjectType}"
-                              CommandParameter="NewBuild"/>
+                              IsChecked="{Binding ProjectType, Mode=TwoWay, Converter={StaticResource ProjectTypeToBoolConverter}, ConverterParameter=NewBuild}"/>
 
-                <!-- REFURBISHMENT RADIO BUTTON -->
+                <!-- REFURBISHMENT RADIO BUTTON Command="{Binding UpdateProjectType}"
+                              CommandParameter="Refurbishment"-->
                 <ToggleButton x:Name="RefurbishedButton"
                               Content="Refurbishment"
                               Style="{StaticResource BuildingTypeButtonStyle}" 
                               Checked="RefurbishedButton_Checked"
-                              Command="{Binding UpdateProjectType}"
-                              CommandParameter="Refurbishment"/>
+                              IsChecked="{Binding ProjectType, Mode=TwoWay, Converter={StaticResource ProjectTypeToBoolConverter}, ConverterParameter=Refurbishment}"/>
             </WrapPanel>
         </StackPanel>
 
@@ -240,7 +243,7 @@
             </ItemsControl>
         </StackPanel>
 
-        <!-- FINAL BUTTON -->
+        <!-- NEXT BUTTON -->
         <Button Content="Next"
                 Grid.Row="18"
                 Grid.Column="2"

--- a/HBERT_Carbon_Emission_Tool/Views/Pages/CarbonEmissionToolPage.xaml.cs
+++ b/HBERT_Carbon_Emission_Tool/Views/Pages/CarbonEmissionToolPage.xaml.cs
@@ -38,12 +38,14 @@ namespace CarbonEmissionTool.Views
 
         private void RefurbishedButton_Checked(object sender, RoutedEventArgs e)
         {
-            this.NewBuildButton.IsChecked = false;
+            if (this.NewBuildButton != null)
+                this.NewBuildButton.IsChecked = false;
         }
 
         private void NewBuildButton_Checked(object sender, RoutedEventArgs e)
         {
-            this.RefurbishedButton.IsChecked = false;
+            if (this.RefurbishedButton != null)
+                this.RefurbishedButton.IsChecked = false;
         }
     }
 }

--- a/RevitAddIn/ButtonData/HbertButtonData.cs
+++ b/RevitAddIn/ButtonData/HbertButtonData.cs
@@ -38,7 +38,9 @@ namespace RevitAddIn.ButtonData
         {
             Document doc = commandData.Application.ActiveUIDocument.Document; // Update the static field to hold current database document
 
-            ApplicationServices.OnStartup(doc);
+            var dataCapture = new DataCapture();
+
+            ApplicationServices.OnStartup(doc, dataCapture);
 
             try
             {


### PR DESCRIPTION
1. Added new UserInputManager
2. Added new InputCapture class which saves the inputs in-session per document and is re-applied when the user re-opens HBERT.
3. Added new value converter to bind to the ProjectType in IProjectDetails so that values can be re-applied when the user re-opens HBERT.
4. Removed ProjectType command from buttons and used IValueConverter instead as a consequence of this update.
5. Added IDataCapture property to ApplicationServices and removed it from IProjectDetails to enable dependency injection at application startup.