### PR TITLE
# Bug fix fatal exception with viewport type setting.

### DIFF
--- a/HBERT Revit Installer/HBERT Installer.vdproj
+++ b/HBERT Revit Installer/HBERT Installer.vdproj
@@ -135,6 +135,12 @@
         }
         "Entry"
         {
+        "MsmKey" = "8:_F73CA2B0FB0E2131CB5D0F50CF1D0802"
+        "OwnerKey" = "8:_8CFFAAB2421840619E03995C0D297141"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_DCC6A81982994D59B58895127C0E030A"
         "MsmSig" = "8:_UNDEFINED"
@@ -149,6 +155,12 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_8CFFAAB2421840619E03995C0D297141"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_F73CA2B0FB0E2131CB5D0F50CF1D0802"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -365,7 +377,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CarbonEmissionTool, Version=2.1.2.0, Culture=neutral, processorArchitecture=AMD64"
+            "AssemblyAsmDisplayName" = "8:CarbonEmissionTool, Version=2.1.3.0, Culture=neutral, processorArchitecture=AMD64"
                 "ScatterAssemblies"
                 {
                     "_6250165CFCB8427AACC7D1CDD3D5E00C"
@@ -747,6 +759,37 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_F73CA2B0FB0E2131CB5D0F50CF1D0802"
+            {
+            "AssemblyRegister" = "3:1"
+            "AssemblyIsInGAC" = "11:FALSE"
+            "AssemblyAsmDisplayName" = "8:System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL"
+                "ScatterAssemblies"
+                {
+                    "_F73CA2B0FB0E2131CB5D0F50CF1D0802"
+                    {
+                    "Name" = "8:System.ValueTuple.DLL"
+                    "Attributes" = "3:512"
+                    }
+                }
+            "SourcePath" = "8:System.ValueTuple.DLL"
+            "TargetName" = "8:"
+            "Tag" = "8:"
+            "Folder" = "8:_A78B64106A0D4C2EB92C7E165FF2B62C"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:TRUE"
+            "IsolateTo" = "8:"
+            }
         }
         "FileType"
         {
@@ -880,15 +923,15 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:HBERT Revit AddIn"
-        "ProductCode" = "8:{140B0F24-4C76-4BE4-9DA3-4950C00981E8}"
-        "PackageCode" = "8:{2FAD0826-7600-4A6A-8460-08077B385870}"
+        "ProductCode" = "8:{F516A378-0350-4458-901C-5150C66FAA84}"
+        "PackageCode" = "8:{9DFF3A9B-7920-43D6-8667-F5199C08B10E}"
         "UpgradeCode" = "8:{4B479C43-03F5-4C54-82CC-D6354DFB3425}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
         "InstallAllUsers" = "11:FALSE"
-        "ProductVersion" = "8:2.1.3"
+        "ProductVersion" = "8:2.1.4"
         "Manufacturer" = "8:Hawkins Brown Architects"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:"

--- a/HBERT_Carbon_Emission_Tool/Models/Utilities/ViewportUtils.cs
+++ b/HBERT_Carbon_Emission_Tool/Models/Utilities/ViewportUtils.cs
@@ -1,5 +1,7 @@
-﻿using Autodesk.Revit.DB;
+﻿using System.Linq;
+using Autodesk.Revit.DB;
 using CarbonEmissionTool.Services;
+using CarbonEmissionTool.Settings;
 
 namespace CarbonEmissionTool.Models
 {
@@ -23,7 +25,9 @@ namespace CarbonEmissionTool.Models
         public static void SetViewportNoTitle(Viewport viewport)
         {
             Parameter param = viewport.get_Parameter(BuiltInParameter.ELEM_TYPE_PARAM);
-            param.Set(ApplicationServices.NoTitleViewportType.Id);
+
+            if (ApplicationServices.NoTitleViewportType != null)
+                param.Set(ApplicationServices.NoTitleViewportType.Id);
         }
 
         /// <summary>
@@ -31,17 +35,17 @@ namespace CarbonEmissionTool.Models
         /// </summary>
         public static ElementType GetNoTitleViewportType()
         {
-            var elementTypes = new FilteredElementCollector(ApplicationServices.Document).OfClass(typeof(ElementType)).WhereElementIsElementType();
+            var elementTypes = new FilteredElementCollector(ApplicationServices.Document).OfClass(typeof(ElementType)).WhereElementIsElementType().Cast<ElementType>();
 
             foreach (ElementType elementType in elementTypes)
             {
-                if (elementType.Name == "No Title")
+                if (elementType.FamilyName == ApplicationSettings.ViewportFamilyName && elementType.Name == ApplicationSettings.NoTitleViewportTypeName)
                 {
                     return elementType;
                 }
             }
 
-            return (ElementType)elementTypes.FirstElement();
+            return (ElementType)elementTypes.FirstOrDefault(e => e.FamilyName == ApplicationSettings.ViewportFamilyName);
         }
     }
 }

--- a/HBERT_Carbon_Emission_Tool/Properties/AssemblyInfo.cs
+++ b/HBERT_Carbon_Emission_Tool/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.3.0")]
-[assembly: AssemblyFileVersion("2.1.3.0")]
+[assembly: AssemblyVersion("2.1.4.0")]
+[assembly: AssemblyFileVersion("2.1.4.0")]

--- a/HBERT_Carbon_Emission_Tool/Settings/ApplicationSettings.cs
+++ b/HBERT_Carbon_Emission_Tool/Settings/ApplicationSettings.cs
@@ -7,6 +7,17 @@ namespace CarbonEmissionTool.Settings
     public class ApplicationSettings
     {
         /// <summary>
+        /// The start name of the 'no title' viewport system type in Revit. Used as the default for placing
+        /// views on the Revit sheet if the name matches a symbol in the active document.
+        /// </summary>
+        public const string NoTitleViewportTypeName = "No Title";
+
+        /// <summary>
+        /// The name of the viewport family in Revit.
+        /// </summary>
+        public const string ViewportFamilyName = "Viewport";
+        
+        /// <summary>
         /// The name of the invisible line style in Revit.
         /// </summary>
         public const string InvisibleLineStyleName = "Invisible lines";


### PR DESCRIPTION
1. If the No Title viewport family type cant be found, the tool defaults to the first type if can find. However the FamilyType entity in Revit is very generic and can be all kinds of different symbols in Revit. Subsequently a non-viewport type was being applied to the viewport which would cause a fata exception if the user attempted to view the sheet after the tool had run. Fixed by handling nulls and filtering only Viewport FamilyName FamilyType's.